### PR TITLE
fix: adding optional remoteRepoToken

### DIFF
--- a/.github/workflows/test-flow.yaml
+++ b/.github/workflows/test-flow.yaml
@@ -87,27 +87,28 @@ jobs:
           remoteRepoToken: ${{ secrets.PRIVATE_TEMPLATE_TEST_PAT }}
           templateBranch: main
           commitMsg: 'build(boilerplate): synchronize template repo'
-        env:
-          CLONE_PAT: ${{ secrets.PRIVATE_TEMPLATE_TEST_PAT }}
+          branchPrefix: ${{ github.head_ref }}
       - name: assert
         run: |
           npx ts-node src/test-utils/confirm-repo-template.ts \
             --expectedPullNumber "${{ steps.test_run.outputs.prNumber }}" \
             --expectedToBranch "main" \
             --expectedFromBranch "main" \
-            --expectedFilesChanged "new_file.md" "package.json" \
-            --expectedFromRepoPath "HanseltimeIndustries/test-private-template"
+            --expectedFilesChanged "new_file.md" "package.json" "templatesync.json" \
+            --expectedFromRepoPath "HanseltimeIndustries/test-private-template" \
+            --expectedBranchPrefix "${{ github.head_ref }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: clean
-      #   if: always()
-      #   run: |
-      #     npx ts-node src/test-utils/clear-int-test-resources.ts \
-      #       --expectedPullNumber "${{ steps.test_run.outputs.prNumber }}" \
-      #       --expectedFromBranch "main" \
-      #       --expectedFromRepoPath "HanseltimeIndustries/test-private-template"
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: clean
+        if: always()
+        run: |
+          npx ts-node src/test-utils/clear-int-test-resources.ts \
+            --expectedPullNumber "${{ steps.test_run.outputs.prNumber }}" \
+            --expectedFromBranch "main" \
+            --expectedFromRepoPath "HanseltimeIndustries/test-private-template" \
+            --expectedBranchPrefix "${{ github.head_ref }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       
     

--- a/.github/workflows/test-flow.yaml
+++ b/.github/workflows/test-flow.yaml
@@ -99,15 +99,15 @@ jobs:
             --expectedFromRepoPath "HanseltimeIndustries/test-private-template"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean
-        if: always()
-        run: |
-          npx ts-node src/test-utils/clear-int-test-resources.ts \
-            --expectedPullNumber "${{ steps.test_run.outputs.prNumber }}" \
-            --expectedFromBranch "main" \
-            --expectedFromRepoPath "HanseltimeIndustries/test-private-template"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: clean
+      #   if: always()
+      #   run: |
+      #     npx ts-node src/test-utils/clear-int-test-resources.ts \
+      #       --expectedPullNumber "${{ steps.test_run.outputs.prNumber }}" \
+      #       --expectedFromBranch "main" \
+      #       --expectedFromRepoPath "HanseltimeIndustries/test-private-template"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       
     

--- a/.github/workflows/test-flow.yaml
+++ b/.github/workflows/test-flow.yaml
@@ -84,6 +84,7 @@ jobs:
         with:
           repoPath: HanseltimeIndustries/test-private-template 
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          remoteRepoToken: ${{ secrets.PRIVATE_TEMPLATE_TEST_PAT }}
           templateBranch: main
           commitMsg: 'build(boilerplate): synchronize template repo'
         env:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   githubToken:
     description: 'The github token with access to write pull requests on this repo'
     required: true
+  remoteRepoToken:
+    description: A separate github token with permissions to clone from the other repo.  Only needed for private repos
+    required: false
   repoRoot:
     description: 'The root in this github repo that we are syncing.  This is mainly for things like monorepos.'
     required: false

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,6 +11,7 @@ const options: GithubOptions = {
     commitMsg: core.getInput('commitMsg') || undefined,
     titleMsg: core.getInput('titleMsg') || undefined,
     prToBranch: core.getInput('prToBranch') || undefined,
+    remoteRepoToken: core.getInput('remoteRepoToken') || undefined,
 }
 
 void syncGithubRepo(options)

--- a/src/sync-github-repo.ts
+++ b/src/sync-github-repo.ts
@@ -17,6 +17,9 @@ export interface GithubOptions {
     /** A github token with access to write pull requests */
     githubToken: string
 
+    /** A separate github token with permissions to clone from the other repo.  Only needed for private repos */
+    remoteRepoToken?: string
+
     /**
      * Normally, this should be the working directory of a github action, but this
      * could also be an internal file depending on things like monorepo structures
@@ -62,12 +65,13 @@ export async function syncGithubRepo(options: GithubOptions) {
     const commitMsg = options.commitMsg ? options.commitMsg : DEFAULT_COMMIT_MSG
 
     // Note, we use git here so that we can change this around for other git providers more easily
-    const repoUrl = `https://github.com/${options.repoPath}`
+    const baseRepoUrl = `github.com/${options.repoPath}.git`
+    const authedRepoUrl = `https://${options.remoteRepoToken ? `github_actions:${options.remoteRepoToken}@` : ''}${baseRepoUrl}`
 
     const branchName = getBranchName({
         branchPrefix,
         templateBranch: options.templateBranch,
-        repoUrl,
+        repoUrl: `https://${baseRepoUrl}`,
         repoRoot,
     })
 
@@ -90,7 +94,7 @@ export async function syncGithubRepo(options: GithubOptions) {
     const result = await templateSync({
         tmpCloneDir: tempAppDir,
         repoDir: options.repoRoot ?? process.cwd(),
-        repoUrl: `https://github_actions:${process.env.CLONE_PAT}@github.com/${options.repoPath}.git`,
+        repoUrl: authedRepoUrl,
     })
 
     // commit everything
@@ -115,7 +119,7 @@ export async function syncGithubRepo(options: GithubOptions) {
         base: prToBranch,
         title: DEFAULT_TITLE_MSG,
         body: `
-Template Synchronization Operation of ${repoUrl} ${options.templateBranch}
+Template Synchronization Operation of ${baseRepoUrl} ${options.templateBranch}
 
 ${syncResultsToMd(result)}
 `

--- a/src/sync-github-repo.ts
+++ b/src/sync-github-repo.ts
@@ -97,6 +97,8 @@ export async function syncGithubRepo(options: GithubOptions) {
     // Checkout the branch from the "to branch"
     execSync(`git fetch origin ${prToBranch}`)
     execSync(`git checkout ${prToBranch}`)
+    // do a reset here to ensure we don't have sneaky build stuff
+    execSync(`git reset --hard`)
     execSync(`git checkout -b ${branchName}`)
 
     // Clone and merge on this branch

--- a/src/test-utils/clear-int-test-resources.ts
+++ b/src/test-utils/clear-int-test-resources.ts
@@ -51,7 +51,7 @@ async function main(options: IntTestCheckOptions) {
       templateBranch: options.expectedFromBranch,
     })
 
-    console.log(`Deleteing branch ${expectedBranchName}...`)
+    console.log(`Deleting branch ${expectedBranchName}...`)
     await octokit.rest.git.deleteRef({
         owner: OWNER,
         repo: REPO,

--- a/src/test-utils/confirm-repo-template.ts
+++ b/src/test-utils/confirm-repo-template.ts
@@ -23,7 +23,7 @@ program
   .requiredOption('--expectedFromBranch <branch>', 'The branch we expect we synced from in the template repo')
   .requiredOption('--expectedFromRepoPath <repo>', 'The ower/repo we expect we synced from in the template repo')
   .option('--expectedTitle <title>', 'If the title is custom, the title to match', DEFAULT_TITLE_MSG)
-  .option('--expectedBranchPrefix', 'If the branhc prefix is custom, the prefix we expect', DEFAULT_BRANCH_PREFIX)
+  .option('--expectedBranchPrefix <prefix>', 'If the branch prefix is custom, the prefix we expect', DEFAULT_BRANCH_PREFIX)
   .option('--expectedRepoRoot <root>', 'The repo root where we expected the merge to occur', process.cwd())
   .helpCommand(true)
 
@@ -45,11 +45,14 @@ program.parse(process.argv)
 async function main(options: IntTestCheckOptions) {
     const pullNumber = parseInt(options.expectedPullNumber)
 
+    console.log(`options is: ${JSON.stringify(options, null, 4)}`)
+
     const octokit = new Octokit({
         auth: process.env.GITHUB_TOKEN
     })
 
     const repoUrl = `https://github.com/${options.expectedFromRepoPath}`
+    console.log('branchPrefix' + options.expectedBranchPrefix)
    const expectedBranchName = getBranchName({
      repoUrl,
      repoRoot: options.expectedRepoRoot,
@@ -59,7 +62,7 @@ async function main(options: IntTestCheckOptions) {
 
    const branchOutput = execSync(`git ls-remote --heads origin ${expectedBranchName}`).toString().trim()
    if (!branchOutput.includes(expectedBranchName)) {
-    throw new Error(`Expected ${expectedBranchName} to be on the repo`)
+    throw new Error(`Expected ${expectedBranchName} to be on the repo2`)
    }
 
    execSync(`git fetch origin ${expectedBranchName}`)


### PR DESCRIPTION
# Summary

Since private repos require PAT tokens in their strings (apparently, because the checkout action doesn't seem to do enough, we consume the option here.