### PR TITLE
fix: only stash pop when there was a stash

### DIFF
--- a/.github/workflows/auto-sync.yaml
+++ b/.github/workflows/auto-sync.yaml
@@ -2,8 +2,8 @@ name: auto-sync-with-template
 
 on:
   schedule:
-  # Perform automatic syncs on saturday at 9 am
-  - cron:  "0 9 * * 6"
+    # Perform automatic syncs on saturday at 9 am
+    - cron: "0 9 * * 6"
   # manual trigger
   workflow_dispatch:
 

--- a/src/sync-github-repo.ts
+++ b/src/sync-github-repo.ts
@@ -161,6 +161,10 @@ export async function syncGithubRepo(options: GithubOptions) {
     console.log(`Resetting to orignal ref: ${origRef}`);
     execSync("git reset --hard");
     execSync(`git checkout ${origRef}`);
-    execSync(`git stash pop`);
+    // In case there were no changes
+    const stashStr = execSync(`git stash list`).toString();
+    if (stashStr.includes("stash@")) {
+      execSync(`git stash pop`);
+    }
   }
 }


### PR DESCRIPTION
# Summary

When there were no changes that needed stashing, the action was failing because you can't pop with nothing in the stash