### PR TITLE
fix: branch naming logic to sha local config

### DIFF
--- a/src/get-branch-name.ts
+++ b/src/get-branch-name.ts
@@ -11,6 +11,13 @@ interface GetBranchNameOptions {
   branchPrefix: string;
 }
 
+/**
+ * Returns the target branch name for our template sync repo
+ * which is derived from the current sha of the template repo and
+ * the current sha of the template.local.json file
+ * @param options
+ * @returns
+ */
 export function getBranchName(options: GetBranchNameOptions) {
   const { branchPrefix, repoRoot, repoUrl, templateBranch } = options;
   const shaLine = execSync(`git ls-remote "${repoUrl}" "${templateBranch}"`)
@@ -25,9 +32,11 @@ export function getBranchName(options: GetBranchNameOptions) {
   }
 
   let configHash: string;
-  if (existsSync(resolve(repoRoot, TEMPLATE_SYNC_LOCAL_CONFIG))) {
+  if (existsSync(resolve(repoRoot, `${TEMPLATE_SYNC_LOCAL_CONFIG}.json`))) {
     configHash = createHash("sha256")
-      .update(readFileSync(resolve(repoRoot, TEMPLATE_SYNC_LOCAL_CONFIG)))
+      .update(
+        readFileSync(resolve(repoRoot, `${TEMPLATE_SYNC_LOCAL_CONFIG}.json`)),
+      )
       .digest("hex")
       .slice(0, 8);
   } else {

--- a/src/test-utils/confirm-repo-template.ts
+++ b/src/test-utils/confirm-repo-template.ts
@@ -104,7 +104,7 @@ async function main(options: IntTestCheckOptions) {
     .toString()
     .trim();
   if (!branchOutput.includes(expectedBranchName)) {
-    throw new Error(`Expected ${expectedBranchName} to be on the repo2`);
+    throw new Error(`Expected ${expectedBranchName} to be on the repo!`);
   }
 
   execSync(`git fetch origin ${expectedBranchName}`);


### PR DESCRIPTION
The local branch name was not actually using local config sha